### PR TITLE
Fix problems with large deploys by updating to async-neocities 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@actions/core": "1.2.6",
-    "async-neocities": "1.1.7",
+    "async-neocities": "2.0.2",
     "ms": "2.1.3",
     "webassert": "3.0.2"
   },
@@ -18,7 +18,7 @@
     "budo": "^11.6.3",
     "cpx2": "^3.0.0",
     "dependency-check": "^4.1.0",
-    "gh-release": "^4.0.0",
+    "gh-release": "^5.0.0",
     "npm-run-all": "^4.1.5",
     "sitedown": "^5.0.0",
     "standard": "^16.0.0"


### PR DESCRIPTION
This should fix issues with larger deploys, by batching them into 50 files at a time. 