### PR TITLE
Update `node-version` to `16`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: 12
+        node-version: 16
     - name: Install deps and build
       run: |
         npm i

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: 16
+        node-version: lts/*
     - name: Install deps and build
       run: |
         npm i


### PR DESCRIPTION
node LTE is currently updated up to 16, so I urge that update.
Of course this should be reflected in https://deploy-to-neocities.neocities.org/ .
Note that this is a pull request that I haven't tested.